### PR TITLE
Fix crash caused by clearing bill

### DIFF
--- a/Durigo/Billing/BillGenerator.swift
+++ b/Durigo/Billing/BillGenerator.swift
@@ -155,11 +155,13 @@ struct BillGenerator: View {
     /// Button to clear all items.
     private var clearButton: some View {
         Button(action: {
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
             showingBillClearAlert.toggle()
         }) {
             Image(systemName: "trash.fill")
         }
         .disabled(menuLoader.billItems.isEmpty)
+        .accessibilityIdentifier("clearBill")
     }
 
     /// Button to add a new item.

--- a/DurigoUITests/DurigoUITests.swift
+++ b/DurigoUITests/DurigoUITests.swift
@@ -184,6 +184,22 @@ final class DurigoUITests: XCTestCase {
         
     }
     
+    func testClearBillClearsAllItems() throws {
+        app.buttons["addItemButton"].tap()
+        
+        let textFieldPredicate = NSPredicate(format: "identifier BEGINSWITH 'menu-item-name-TextField'")
+        let textField = app.textFields.matching(textFieldPredicate).firstMatch
+        textField.tap()
+        app.buttons["clearBill"].tap()
+        
+        let alert = app.alerts.firstMatch
+        
+        alert.buttons["Clear"].tap()
+        
+        XCTAssertFalse(textField.exists, "Bill is not cleared")
+        
+    }
+    
     func testLaunchPerformance() throws {
         if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
             // This measures how long it takes to launch your application.


### PR DESCRIPTION
- Fix crash caused by clearing bill when a text field is selected

When a tex field is removed from view when it is in focus caused the application to crash. To prevent this when clear bill button is clicked, the first responder is resigned, so that the text field is not in focus when it is being removed from view